### PR TITLE
Montado socket de docker para portainer

### DIFF
--- a/docker-swarm.yml
+++ b/docker-swarm.yml
@@ -14,6 +14,8 @@ services:
     image: portainer/portainer:latest
     ports:
       - 9000:9000
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
 
 secrets:
   jenkins-user:


### PR DESCRIPTION
montado docker.sock. Falta añadir usuario y contraseña de portainer desde secrets.